### PR TITLE
Change bindingTypes from Enum to Custom Metadat

### DIFF
--- a/force-di/bindingType/classes/di_ApexBinding.cls
+++ b/force-di/bindingType/classes/di_ApexBinding.cls
@@ -1,0 +1,36 @@
+/**
+ * File Name: di_ApexBinding 
+ * Description: Bindings to Apex classes (optionally via Provider interface)
+ */
+public with sharing class di_ApexBinding extends di_Binding
+{
+	public override Object newInstance(Object params)
+	{
+		// Type binding?
+		if ( To instanceof String )
+		{
+			// Leverage namespace if the Binding has one
+			String className = (String) To;
+			Type toType = NameSpacePrefix==null ? Type.forName(className) : Type.forName(NamespacePrefix, className);
+			if ( toType == null )
+			{
+				throw new BindingException('Apex binding ' + DeveloperName + ' implementation ' + To + ' does not exist');
+			}
+			Object toObject = toType.newInstance();
+			// Is this Apex binding resolved via a Provider?
+			IsProvider = toObject instanceof Provider;
+			if ( IsProvider )
+			{
+				return ((Provider) toObject).newInstance(params);
+			}
+			else if ( params != null )
+			{
+				// Params supplied but the binding does not reference a Provider?
+				throw new BindingException('Apex binding ' + DeveloperName + ' implementation ' + className + ' does not implement the Provider interface.');
+			}
+			return toObject;
+		}
+		// Instance binding
+		return To;
+	}
+}

--- a/force-di/bindingType/classes/di_ApexBinding.cls-meta.xml
+++ b/force-di/bindingType/classes/di_ApexBinding.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>47.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-di/bindingType/classes/di_FlowBinding.cls
+++ b/force-di/bindingType/classes/di_FlowBinding.cls
@@ -1,0 +1,22 @@
+/**
+ * File Name: di_FlowBinding 
+ * Description: Bindings to Flows (Provider interface not currently supported)
+ */
+public with sharing class di_FlowBinding extends di_Binding
+{
+	public  override Object newInstance(Object params)
+	{
+		// Flow name binding?
+		if ( To instanceof String )
+		{
+			String flowName = (String) To;
+			if ( params instanceof Map<String, Object> )
+			{
+				return new di_Flow(Flow.Interview.createInterview(flowName, (Map<String, Object>) params));
+			}
+			return new di_Flow(Flow.Interview.createInterview(flowName, new Map<String, Object>()));
+		}
+		// Instance binding
+		return To;
+	}
+}

--- a/force-di/bindingType/classes/di_FlowBinding.cls-meta.xml
+++ b/force-di/bindingType/classes/di_FlowBinding.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>47.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-di/bindingType/classes/di_LightningComponentBinding.cls
+++ b/force-di/bindingType/classes/di_LightningComponentBinding.cls
@@ -1,0 +1,12 @@
+/**
+ * File Name: di_LightningComponentBinding 
+ * Description: Bindings to Lightning Components (Provider interface not currently supported)
+ */
+public with sharing class di_LightningComponentBinding extends di_Binding
+{
+	public override Object newInstance(Object params)
+	{
+		// Lightning Component bindings are resolve by the Lightning 'inject' Component included in this library
+		return To;
+	}
+}

--- a/force-di/bindingType/classes/di_LightningComponentBinding.cls-meta.xml
+++ b/force-di/bindingType/classes/di_LightningComponentBinding.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>47.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-di/bindingType/classes/di_VisualForceComponentBinding.cls
+++ b/force-di/bindingType/classes/di_VisualForceComponentBinding.cls
@@ -1,0 +1,31 @@
+/**
+ * File Name: di_VisualForceComponentBinding 
+ * Description: Bindings to VF Components via Provider interface (required)
+ */
+public with sharing class di_VisualForceComponentBinding extends di_Binding
+{
+	public  override Object newInstance(Object params)
+	{
+		// Type binding?
+		if ( To instanceof String )
+		{
+			// Visualforce Components references must be made via an Apex class implementing the Provider interface
+			String className = (String) To;
+			Type toType = NamespacePrefix==null ? Type.forName(className) : Type.forName(NamespacePrefix, className);
+			if ( toType==null )
+			{
+				throw new BindingException('Visualforce Component binding ' + DeveloperName + ' implementation ' + className + ' does not exist.');
+			}
+			// Visualforce Components have to be resolved via a Provider
+			Object toObject = toType.newInstance();
+			IsProvider = toObject instanceof Provider;
+			if ( IsProvider )
+			{
+				return ((Provider) toObject).newInstance(params);
+			}
+			throw new BindingException('Visualforce Component binding ' + DeveloperName + ' must point to a class implementing the Provider interface.');
+		}
+		// Instance binding
+		return To;
+	}
+}

--- a/force-di/bindingType/classes/di_VisualForceComponentBinding.cls-meta.xml
+++ b/force-di/bindingType/classes/di_VisualForceComponentBinding.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>47.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-di/bindingType/customMetadata/di_BindingType.Apex.md-meta.xml
+++ b/force-di/bindingType/customMetadata/di_BindingType.Apex.md-meta.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <label>Apex</label>
+    <protected>false</protected>
+    <values>
+        <field>Type__c</field>
+        <value xsi:type="xsd:string">di_ApexBinding</value>
+    </values>
+</CustomMetadata>

--- a/force-di/bindingType/customMetadata/di_BindingType.Flow.md-meta.xml
+++ b/force-di/bindingType/customMetadata/di_BindingType.Flow.md-meta.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <label>Flow</label>
+    <protected>false</protected>
+    <values>
+        <field>Type__c</field>
+        <value xsi:type="xsd:string">di_FlowBinding</value>
+    </values>
+</CustomMetadata>

--- a/force-di/bindingType/customMetadata/di_BindingType.LightningComponent.md-meta.xml
+++ b/force-di/bindingType/customMetadata/di_BindingType.LightningComponent.md-meta.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <label>Lightning Component</label>
+    <protected>false</protected>
+    <values>
+        <field>Type__c</field>
+        <value xsi:type="xsd:string">di_LightningComponentBinding</value>
+    </values>
+</CustomMetadata>

--- a/force-di/bindingType/customMetadata/di_BindingType.Module.md-meta.xml
+++ b/force-di/bindingType/customMetadata/di_BindingType.Module.md-meta.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <label>Module</label>
+    <protected>false</protected>
+    <values>
+        <field>Type__c</field>
+        <value xsi:type="xsd:string">di_ApexBinding</value>
+    </values>
+</CustomMetadata>

--- a/force-di/bindingType/customMetadata/di_BindingType.VisualforceComponent.md-meta.xml
+++ b/force-di/bindingType/customMetadata/di_BindingType.VisualforceComponent.md-meta.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <label>Visualforce Component</label>
+    <protected>false</protected>
+    <values>
+        <field>Type__c</field>
+        <value xsi:type="xsd:string">di_VisualForceComponentBinding</value>
+    </values>
+</CustomMetadata>

--- a/force-di/main/classes/di_Binding.cls
+++ b/force-di/main/classes/di_Binding.cls
@@ -30,10 +30,8 @@
  **/
 public abstract class di_Binding implements Comparable {
 
-    public BindingType BindingType {get; private set;}
-
     @AuraEnabled
-    public String BindingTypeAsString {get { return BindingType.name();} }
+    public String BindingType { get; private set; }
 
     @AuraEnabled
     public String NamespacePrefix {get;private set;}
@@ -53,7 +51,7 @@ public abstract class di_Binding implements Comparable {
     @AuraEnabled
     public Object Data {get;private set;}
 
-    private Boolean IsProvider = false;
+    protected Boolean IsProvider = false;
     private Object Injected = null;
 
     /**
@@ -119,7 +117,7 @@ public abstract class di_Binding implements Comparable {
         // Filter params for resolving bindings
         private String developerName;
         private SObjectType bindingObject;
-        private boolean bindingsAreRequired = true;
+        private Boolean bindingsAreRequired = true;
         
         // Modules used by the Resolver to discover bindings
         private List<di_Module> modules = null;
@@ -206,7 +204,7 @@ public abstract class di_Binding implements Comparable {
             {
                 if ( isBindingMatchByFilteringCriteria( this.bindings[currentBindingsIndex] ) )
                 {
-                    this.bindings[currentBindingsIndex] = di_Binding.newInstance(di_Binding.BindingType.Apex, this.developerName, this.bindingObject, null, mockType, null);
+                    this.bindings[currentBindingsIndex] = di_Binding.newInstance('Apex', this.developerName, this.bindingObject, null, mockType, null);
                     break;
                 }
             }
@@ -282,11 +280,14 @@ public abstract class di_Binding implements Comparable {
                 {
                     module.configure();
                     for(di_Binding bind : module.getBindings()) {
-                        if(bind.BindingType == di_Binding.BindingType.Module) {
+                        if (bind.BindingType.equalsIgnoreCase('Module'))
+                        {
                             di_Module embeddedModule = (di_Module) bind.getInstance();
                             embeddedModule.configure();
                             this.bindings.addAll(embeddedModule.getBindings());
-                        } else {
+                        }
+                        else
+                        {
                             this.bindings.add(bind);
                         }
                     }
@@ -300,7 +301,7 @@ public abstract class di_Binding implements Comparable {
          **/
         public List<di_Binding> get() 
         {
-            list<di_Binding> matchedBindings = di_PlatformCache.getInstance().retrieveBindings(this.developerName, this.bindingObject);
+            List<di_Binding> matchedBindings = di_PlatformCache.getInstance().retrieveBindings(this.developerName, this.bindingObject);
             
             if ( ( bindingsAreRequired && matchedBindings.isEmpty() && di_PlatformCache.isStoringBindingInPlatformCache() ) 
                 || ! di_PlatformCache.isStoringBindingInPlatformCache()
@@ -334,23 +335,18 @@ public abstract class di_Binding implements Comparable {
     public class BindingException extends Exception {}
 
     /**
-     * Types of Binding implementations supported by the framework
-     **/
-    public enum BindingType { Apex, VisualforceComponent, LightningComponent, Flow, Module }
-
-    /**
      * Returns the applicable Binding impl to resolve the type of binding provided
      **/
     public static di_Binding newInstance(
-            BindingType bindType,
+            String bindType,
             String developerName,
             SObjectType bindingObject,
             Integer bindingSequence,
             Object to,
-            Object bindingData) 
+            Object bindingData)
     {
         // Return an applicable Binding subclass for the given binding type
-        Type implType = BINDING_IMPLS_BY_TYPE.get(bindType);
+        Type implType = di_BindingTypes.getInstance().getType(bindType);
 
         if ( implType != null ) {
             di_Binding binding = (di_Binding) implType.newInstance();
@@ -363,116 +359,5 @@ public abstract class di_Binding implements Comparable {
             return binding;
         }
         throw new BindingException('Binding type ' + bindType + ' has no implementation.');
-    }
-
-    // Maps binding type to the applicable impl
-    private static final Map<BindingType, Type> BINDING_IMPLS_BY_TYPE =
-        new Map<BindingType, Type> {
-            BindingType.Apex => ApexBinding.class,
-            BindingType.LightningComponent => LightningComponentBinding.class,
-            BindingType.VisualforceComponent => VisualForceComponentBinding.class,
-            BindingType.Flow => FlowBinding.class,
-            BindingType.Module => ApexBinding.class
-        };
-
-    /**
-     * Bindings to Apex classes (optionally via Provider interface)
-     **/
-    private class ApexBinding extends di_Binding 
-    {
-        public override Object newInstance(Object params) 
-        {
-            // Type binding?
-            if ( To instanceof String ) 
-            {
-                // Leverage namespace if the Binding has one
-                String className = (String) To;
-                Type toType = NameSpacePrefix==null ? Type.forName(className) : Type.forName(NamespacePrefix, className);
-                if ( toType == null ) 
-                {
-                    throw new BindingException('Apex binding ' + DeveloperName + ' implementation ' + To + ' does not exist');
-                }
-                Object toObject = toType.newInstance();
-                // Is this Apex binding resolved via a Provider?
-                IsProvider = toObject instanceof Provider;
-                if ( IsProvider )
-                {
-                    return ((Provider) toObject).newInstance(params);
-                } 
-                else if ( params != null ) 
-                {
-                    // Params supplied but the binding does not reference a Provider?
-                    throw new BindingException('Apex binding ' + DeveloperName + ' implementation ' + className + ' does not implement the Provider interface.');
-                }
-                return toObject;
-            }
-            // Instance binding
-            return To;
-        }
-    }
-
-    /**
-     * Bindings to VF Components via Provider interface (required)
-     **/
-    private class VisualForceComponentBinding extends di_Binding 
-    {
-        public  override Object newInstance(Object params) 
-        {
-            // Type binding?
-            if ( To instanceof String ) 
-            {
-                // Visualforce Components references must be made via an Apex class implementing the Provider interface
-                String className = (String) To;
-                Type toType = NamespacePrefix==null ? Type.forName(className) : Type.forName(NamespacePrefix, className);
-                if ( toType==null )
-                {
-                    throw new BindingException('Visualforce Component binding ' + DeveloperName + ' implementation ' + className + ' does not exist.');
-                }
-                // Visualforce Components have to be resolved via a Provider
-                Object toObject = toType.newInstance();
-                IsProvider = toObject instanceof Provider;
-                if ( IsProvider )
-                {
-                    return ((Provider) toObject).newInstance(params);
-                }
-                throw new BindingException('Visualforce Component binding ' + DeveloperName + ' must point to a class implementing the Provider interface.');
-            }
-            // Instance binding
-            return To;
-        }
-    }
-
-    /**
-     * Bindings to Lightning Components (Provider interface not currently supported)
-     **/
-    private class LightningComponentBinding extends di_Binding 
-    {
-        public override Object newInstance(Object params) 
-        {
-            // Lightning Component bindings are resolve by the Lightning 'inject' Component included in this library
-            return To;
-        }
-    }
-
-    /**
-     * Bindings to Flows (Provider interface not currently supported)
-     **/
-    private class FlowBinding extends di_Binding 
-    {
-        public  override Object newInstance(Object params) 
-        {
-            // Flow name binding?
-            if ( To instanceof String ) 
-            {
-                String flowName = (String) To;
-                if ( params instanceof Map<String, Object> )
-                {
-                    return new di_Flow(Flow.Interview.createInterview(flowName, (Map<String, Object>) params));
-                }
-                return new di_Flow(Flow.Interview.createInterview(flowName, new Map<String, Object>()));
-            }
-            // Instance binding
-            return To;
-        }
     }
 }

--- a/force-di/main/classes/di_BindingTypes.cls
+++ b/force-di/main/classes/di_BindingTypes.cls
@@ -1,0 +1,75 @@
+/**
+ * File Name: di_BindingTypes 
+ * Description:
+ */
+public virtual with sharing class di_BindingTypes
+{
+	private static di_BindingTypes instance;
+
+	protected Map<String, di_BindingType__mdt> bindingTypeByName
+	{
+		get
+		{
+			if (bindingTypeByName == null)
+			{
+				bindingTypeByName = new Map<String, di_BindingType__mdt>();
+				for (di_BindingType__mdt record :
+				[
+						SELECT QualifiedAPIName,
+								DeveloperName,
+								NamespacePrefix,
+								Type__c
+						FROM di_BindingType__mdt
+				])
+				{
+					bindingTypeByName.put(
+							record.QualifiedApiName.toLowerCase(),
+							record
+					);
+				}
+			}
+			return bindingTypeByName;
+		}
+		private set;
+	}
+
+	public static di_BindingTypes getInstance()
+	{
+		if (di_BindingTypes.instance == null)
+		{
+			di_BindingTypes.instance = new di_BindingTypes();
+		}
+		return di_BindingTypes.instance;
+	}
+
+	public Boolean isValid(String bindingTypeName)
+	{
+		return String.isNotBlank(bindingTypeName) &&
+				bindingTypeByName.containsKey(bindingTypeName.toLowerCase());
+	}
+
+	public Type getType(String bindingTypeName)
+	{
+		di_BindingType__mdt bindingType = getBindingType(bindingTypeName);
+		if (bindingType == null)
+		{
+			return null;
+		}
+
+		return Type.forName(
+				bindingType.Type__c
+		);
+	}
+
+
+	private di_BindingType__mdt getBindingType(String bindingTypeName)
+	{
+		if (!isValid(bindingTypeName))
+		{
+			// todo - throw exception
+			return null;
+		}
+
+		return bindingTypeByName.get(bindingTypeName.toLowerCase());
+	}
+}

--- a/force-di/main/classes/di_BindingTypes.cls-meta.xml
+++ b/force-di/main/classes/di_BindingTypes.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>47.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-di/main/classes/di_InjectorComponentController.cls
+++ b/force-di/main/classes/di_InjectorComponentController.cls
@@ -34,7 +34,7 @@ public with sharing class di_InjectorComponentController {
         ApexPages.Component cmp = null;
         di_Binding bindingInfo = getBinding(BindingNameValue);
         switch on bindingInfo.BindingType {
-            when Flow {
+            when 'Flow' {
                 cmp = (ApexPages.Component) getInjectorFlowProxyInstance((String) bindingInfo.To, ParametersValue);
             }
             when else {

--- a/force-di/main/classes/di_Module.cls
+++ b/force-di/main/classes/di_Module.cls
@@ -33,7 +33,7 @@
 public virtual class di_Module {
 
     private List<di_Binding> bindings = new List<di_Binding>();
-    private di_Binding.BindingType bindingType;
+    private String bindingType;
     private String developerName;
     private SObjectType bindingObject;
     private Integer bindingSequence;
@@ -55,30 +55,21 @@ public virtual class di_Module {
     /**
      * Type of binding, see also alias methods apex(), lightningComponent(), visualforceComponent()
      **/
-    public di_Module type(String value) {
-        List<di_Binding.BindingType> bindEnumValues = di_Binding.BindingType.values();
-        for(di_Binding.BindingType bindEnumValue : bindEnumValues) {
-            if(bindEnumValue.name().equals(value)) {
-                bindingType = bindEnumValue;
-                return this;
-            }
+    public di_Module type(String value)
+    {
+        if (di_BindingTypes.getInstance().isValid(value))
+        {
+            bindingType = value;
+            return this;
         }
         throw new ModuleException('Binding type ' + value + ' is not valid.');
     }
 
     /**
-     * Type of binding
+     * Sets the binding type
      **/
-    public di_Module type(di_Binding.BindingType value) {
-        bindingType = value;
-        return this;
-    }
-
-    /**
-     * Sets the binding type to Apex
-     **/
-    public di_Module apex() {
-        bindingType = di_Binding.BindingType.Apex;
+    public di_Module setBindingType(String bindingType) {
+        this.bindingType = bindingType;
         return this;
     }
 
@@ -86,7 +77,7 @@ public virtual class di_Module {
      * Sets the binding type to Lightning Component
      **/
     public di_Module lightningComponent() {
-        bindingType = di_Binding.BindingType.LightningComponent;
+        setBindingType('LightningComponent');
         return this;
     }
 
@@ -94,7 +85,7 @@ public virtual class di_Module {
      * Sets the binding type to Visualforce Component
      **/
     public di_Module visualforceComponent() {
-        bindingType = di_Binding.BindingType.VisualforceComponent;
+        setBindingType('VisualforceComponent');
         return this;
     }
 
@@ -102,7 +93,7 @@ public virtual class di_Module {
      * Sets the binding type to Flow
      **/
     public di_Module flow() {
-        bindingType = di_Binding.BindingType.Flow;
+        setBindingType('Flow');
         return this;
     }
 
@@ -110,7 +101,7 @@ public virtual class di_Module {
      * Sets the binding type to Module (Apex class binding must extend Module class)
      **/
     public di_Module module() {
-        bindingType = di_Binding.BindingType.Module;
+        setBindingType('Module');
         return this;
     }
 
@@ -176,7 +167,7 @@ public virtual class di_Module {
         this.to = to;
         // Attempt to auto infer type of binding
         if(to instanceof di_Flow) {
-            return flow().addBinding();
+            return setBindingType('flow').addBinding();
         }
         return addBinding();
     }
@@ -209,7 +200,7 @@ public virtual class di_Module {
 
     private void init() {
         // Reset state
-        bindingType = di_Binding.BindingType.Apex;
+        bindingType = 'Apex';
         developerName = null;
         bindingObject = null;
         bindingSequence = null;

--- a/force-di/main/objects/di_BindingType__mdt/di_BindingType__mdt.object-meta.xml
+++ b/force-di/main/objects/di_BindingType__mdt/di_BindingType__mdt.object-meta.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomObject xmlns="http://soap.sforce.com/2006/04/metadata">
+    <label>Binding Type</label>
+    <pluralLabel>Binding Types</pluralLabel>
+    <visibility>Public</visibility>
+</CustomObject>

--- a/force-di/main/objects/di_BindingType__mdt/fields/Type__c.field-meta.xml
+++ b/force-di/main/objects/di_BindingType__mdt/fields/Type__c.field-meta.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Type__c</fullName>
+    <description>The name of the class that manages the binding type which extended from di_Binding</description>
+    <externalId>false</externalId>
+    <fieldManageability>SubscriberControlled</fieldManageability>
+    <label>Implementation class</label>
+    <length>255</length>
+    <required>true</required>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>

--- a/force-di/test/classes/di_BindingTest.cls
+++ b/force-di/test/classes/di_BindingTest.cls
@@ -31,7 +31,7 @@ private class di_BindingTest {
     private static void givenApexBindingWhenGetInstanceThenInstance() {
         // Given
         di_Binding binding = di_Binding.newInstance(
-            di_Binding.BindingType.Apex,
+            'Apex',
             Bob.class.getName(), null, null, Bob.class.getName(), null);
         // When
         Object boundInstance1 = binding.getInstance();
@@ -45,7 +45,7 @@ private class di_BindingTest {
     private static void givenApexBindingWhenGetInstanceWithParamThenInstanceWithParam() {
         // Given
         di_Binding binding = di_Binding.newInstance(
-            di_Binding.BindingType.Apex,
+            'Apex',
             Bob.class.getName(), null, null, ProviderImpl.class.getName(), null);
         // When
         Object boundInstance1 = binding.getInstance('Some value 1');
@@ -62,7 +62,7 @@ private class di_BindingTest {
         try{
             //When
             di_Binding binding = di_Binding.newInstance(
-            null, Bob.class.getName(), null, null, ProviderImpl.class.getName(), null);
+                    null, Bob.class.getName(), null, null, ProviderImpl.class.getName(), null);
             System.assert(false, 'No Exception was thrown.');
         } catch(Exception ex){
             //Then
@@ -72,59 +72,59 @@ private class di_BindingTest {
     
     @IsTest
     private static void givenApexBindingsWithDeveloperNamesWhenSortThenReturnSortedBindingsList() {
-        
+
         List<di_Binding> bindings = new List<di_Binding>();
         List<di_Binding> sortedExpectedBindings = new List<di_Binding>();
-        
+
         di_Binding zoroBinding = di_Binding.newInstance(
-            di_Binding.BindingType.Apex,
+            'Apex',
             Zoro.class.getName(), null, null, ProviderImpl.class.getName(), null);
         bindings.add(zoroBinding);
-        
+
         di_Binding charlieBinding = di_Binding.newInstance(
-            di_Binding.BindingType.Apex,
+            'Apex',
             Charlie.class.getName(), null, null, ProviderImpl.class.getName(), null);
         bindings.add(charlieBinding);
-        
+
         di_Binding bobBinding = di_Binding.newInstance(
-            di_Binding.BindingType.Apex,
+            'Apex',
             Bob.class.getName(), null, null, ProviderImpl.class.getName(), null);
         bindings.add(bobBinding);
-        
+
         bindings.sort();
-        
+
         //Sorted based on developer names
         sortedExpectedBindings.add(bobBinding);
         sortedExpectedBindings.add(charlieBinding);
         sortedExpectedBindings.add(zoroBinding);
-        
-        
+
+
         System.assertEquals(sortedExpectedBindings, bindings, 'Binding sorted by default Developer Names');
     }
     
     @IsTest
     private static void givenApexBindingsWithSobjectTypesWhenSortThenReturnSortedBindingsList() {
-        
+
         List<di_Binding> bindings = new List<di_Binding>();
         List<di_Binding> sortedExpectedBindings = new List<di_Binding>();
-        
+
         di_Binding zoroBinding = di_Binding.newInstance(
-            di_Binding.BindingType.Apex,
+            'Apex',
             Zoro.class.getName(), Contact.sObjectType, null, ProviderImpl.class.getName(), null);
         bindings.add(zoroBinding);
-        
+
         di_Binding charlieBinding = di_Binding.newInstance(
-            di_Binding.BindingType.Apex,
+            'Apex',
             Charlie.class.getName(), Account.sObjectType, null, ProviderImpl.class.getName(), null);
         bindings.add(charlieBinding);
-        
+
         di_Binding bobBinding = di_Binding.newInstance(
-            di_Binding.BindingType.Apex,
+            'Apex',
             Bob.class.getName(), Opportunity.sObjectType, null, ProviderImpl.class.getName(), null);
         bindings.add(bobBinding);
-        
+
         bindings.sort();
-        
+
         //Sorted based on binding sObject types
         sortedExpectedBindings.add(charlieBinding);
         sortedExpectedBindings.add(zoroBinding);
@@ -135,27 +135,27 @@ private class di_BindingTest {
     
     @IsTest
     private static void givenApexBindingsWithSequenceWhenSortThenReturnSortedBindingsList() {
-        
+
         List<di_Binding> bindings = new List<di_Binding>();
         List<di_Binding> sortedExpectedBindings = new List<di_Binding>();
-        
+
         di_Binding zoroBinding = di_Binding.newInstance(
-            di_Binding.BindingType.Apex,
+            'Apex',
             Zoro.class.getName(), Contact.sObjectType, 2, ProviderImpl.class.getName(), null);
         bindings.add(zoroBinding);
-        
+
         di_Binding charlieBinding = di_Binding.newInstance(
-            di_Binding.BindingType.Apex,
+            'Apex',
             Charlie.class.getName(), Account.sObjectType, 3, ProviderImpl.class.getName(), null);
         bindings.add(charlieBinding);
-        
+
         di_Binding bobBinding = di_Binding.newInstance(
-            di_Binding.BindingType.Apex,
+            'Apex',
             Bob.class.getName(), Account.sObjectType, 1, ProviderImpl.class.getName(), null);
         bindings.add(bobBinding);
-        
+
         bindings.sort();
-        
+
         //Sorted based on binding sequence
         sortedExpectedBindings.add(bobBinding);
         sortedExpectedBindings.add(charlieBinding);


### PR DESCRIPTION
The hardcoded bindingType Enum is moved to Custom Meta data to allow additional binding types without having to modify existing source code. It also simplifies existing classes and makes them smaller.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/apex-enterprise-patterns/force-di/59)
<!-- Reviewable:end -->
