### PR TITLE
Remove Caching of the Injected Object from di_Binding

### DIFF
--- a/force-di/main/classes/di_Binding.cls
+++ b/force-di/main/classes/di_Binding.cls
@@ -75,7 +75,7 @@ public abstract class di_Binding implements Comparable {
      * Gets the instance of the thing the binding points to
      **/
     public Object getInstance(Object params) {
-        return getInstance(params, false)
+        return getInstance(params, false);
     }
 
     /**

--- a/force-di/main/classes/di_Binding.cls
+++ b/force-di/main/classes/di_Binding.cls
@@ -54,19 +54,42 @@ public abstract class di_Binding implements Comparable {
     public Object Data {get;private set;}
 
     private Boolean IsProvider = false;
+    private Object Injected = null;
 
     /**
      * Gets the instance of the thing the binding points to
      **/
     public Object getInstance() {
-        return getInstance(null);
+        return getInstance(false);
+    }
+
+    /**
+     * Gets the instance of the thing the binding points to
+     * @param newInstance if a new instance should always be returned
+     **/
+    public Object getInstance(Boolean newInstance) {
+        return getInstance(newInstance, null);
     }
 
     /**
      * Gets the instance of the thing the binding points to
      **/
     public Object getInstance(Object params) {
-        return newInstance(params);
+        return getInstance(params, false)
+    }
+
+    /**
+     * Gets the instance of the thing the binding points to
+     **/
+    public Object getInstance(Object params, Boolean newInstance) {
+        if(IsProvider) {
+            return newInstance(params);
+        } else if(newInstance==true) {
+            return newInstance(params);
+        } else if(Injected==null) {
+            Injected = newInstance(params);
+        }
+        return Injected;
     }
 
     /**

--- a/force-di/main/classes/di_Binding.cls
+++ b/force-di/main/classes/di_Binding.cls
@@ -54,7 +54,6 @@ public abstract class di_Binding implements Comparable {
     public Object Data {get;private set;}
 
     private Boolean IsProvider = false;
-    private Object Injected = null;
 
     /**
      * Gets the instance of the thing the binding points to

--- a/force-di/main/classes/di_Binding.cls
+++ b/force-di/main/classes/di_Binding.cls
@@ -63,13 +63,6 @@ public abstract class di_Binding implements Comparable {
         return getInstance(null, false);
     }
 
-        /**
-     * Gets the instance of the thing the binding points to
-     **/
-    public Object getInstance(Boolean newInstance) {
-        return getInstance(null, newInstance);
-    }
-
     /**
      * Gets the instance of the thing the binding points to
      **/

--- a/force-di/main/classes/di_Binding.cls
+++ b/force-di/main/classes/di_Binding.cls
@@ -69,10 +69,9 @@ public abstract class di_Binding implements Comparable {
     public Object getInstance(Object params) {
         if(IsProvider) {
             return newInstance(params);
-        } else if(Injected==null) {
-            Injected = newInstance(params);
-        }
-        return Injected;
+        } 
+        
+        return newInstance(params);
     }
 
     /**

--- a/force-di/main/classes/di_Binding.cls
+++ b/force-di/main/classes/di_Binding.cls
@@ -60,31 +60,18 @@ public abstract class di_Binding implements Comparable {
      * Gets the instance of the thing the binding points to
      **/
     public Object getInstance() {
-        return getInstance(false);
+        return getInstance(null);
     }
 
-    /**
-     * Gets the instance of the thing the binding points to
-     * @param newInstance if a new instance should always be returned
-     **/
-    public Object getInstance(Boolean newInstance) {
-        return getInstance(newInstance, null);
+    public Object getNewInstance() {
+        return getNewInstance(null);
     }
 
     /**
      * Gets the instance of the thing the binding points to
      **/
     public Object getInstance(Object params) {
-        return getInstance(params, false);
-    }
-
-    /**
-     * Gets the instance of the thing the binding points to
-     **/
-    public Object getInstance(Object params, Boolean newInstance) {
         if(IsProvider) {
-            return newInstance(params);
-        } else if(newInstance==true) {
             return newInstance(params);
         } else if(Injected==null) {
             Injected = newInstance(params);

--- a/force-di/main/classes/di_Binding.cls
+++ b/force-di/main/classes/di_Binding.cls
@@ -66,10 +66,6 @@ public abstract class di_Binding implements Comparable {
      * Gets the instance of the thing the binding points to
      **/
     public Object getInstance(Object params) {
-        if(IsProvider) {
-            return newInstance(params);
-        } 
-        
         return newInstance(params);
     }
 

--- a/force-di/main/classes/di_Binding.cls
+++ b/force-di/main/classes/di_Binding.cls
@@ -63,13 +63,17 @@ public abstract class di_Binding implements Comparable {
         return getInstance(null, false);
     }
 
+        /**
+     * Gets the instance of the thing the binding points to
+     **/
+    public Object getInstance(Boolean newInstance) {
+        return getInstance(null, newInstance);
+    }
+
     /**
      * Gets the instance of the thing the binding points to
      **/
     public Object getInstance(Object params) {
-        if (params instanceOf Boolean) {
-            return getInstance(null, (Boolean) params);
-        }
         return getInstance(params, false);
     }
 

--- a/force-di/main/classes/di_Binding.cls
+++ b/force-di/main/classes/di_Binding.cls
@@ -60,18 +60,26 @@ public abstract class di_Binding implements Comparable {
      * Gets the instance of the thing the binding points to
      **/
     public Object getInstance() {
-        return getInstance(null);
-    }
-
-    public Object getNewInstance() {
-        return getNewInstance(null);
+        return getInstance(null, false);
     }
 
     /**
      * Gets the instance of the thing the binding points to
      **/
     public Object getInstance(Object params) {
+        if (params instanceOf Boolean) {
+            return getInstance(null, (Boolean) params);
+        }
+        return getInstance(params, false);
+    }
+
+    /**
+     * Gets the instance of the thing the binding points to
+     **/
+    public Object getInstance(Object params, Boolean newInstance) {
         if(IsProvider) {
+            return newInstance(params);
+        } else if(newInstance==true) {
             return newInstance(params);
         } else if(Injected==null) {
             Injected = newInstance(params);

--- a/force-di/main/classes/di_Injector.cls
+++ b/force-di/main/classes/di_Injector.cls
@@ -60,7 +60,7 @@ public class di_Injector {
      * Creates an instance of the object configured for the class name binding
      **/
     public Object getInstance(Type developerNameByType) {
-        return getInstance(developerNameByType == null ? null : developerNameByType.getName().toLowerCase(), null);
+        return getInstance(developerNameByType?.getName()?.toLowerCase(), null);
     }
 
     /**
@@ -68,7 +68,7 @@ public class di_Injector {
      *   (if params is specified, implicitly uses the Provider interface)
      **/
     public Object getInstance(Type developerNameByType, Object params) {
-        return getInstance(developerNameByType == null ? null : developerNameByType.getName().toLowerCase(), params);
+        return getInstance(developerNameByType?.getName()?.toLowerCase(), params);
     }
 
     /**

--- a/force-di/test/classes/di_BindingTest.cls
+++ b/force-di/test/classes/di_BindingTest.cls
@@ -39,7 +39,20 @@ private class di_BindingTest {
         Object boundInstance2 = binding.getInstance();
         // Then
         System.assert(boundInstance1 instanceof Bob);
-        System.assert(boundInstance2 instanceof Bob);
+        System.assert(boundInstance1 === boundInstance2);
+    }
+
+    @IsTest
+    private static void givenApexBindingWhenGetNewInstanceThenNewInstance() {
+        // Given
+        di_Binding binding = di_Binding.newInstance(
+            di_Binding.BindingType.Apex,
+            Bob.class.getName(), null, null, Bob.class.getName(), null);
+        // When
+        Object boundInstance1 = binding.getInstance(true);
+        Object boundInstance2 = binding.getInstance(true);
+        // Then
+        System.assert(boundInstance1 instanceof Bob);
         System.assert(boundInstance1 !== boundInstance2);
     }
 

--- a/force-di/test/classes/di_BindingTest.cls
+++ b/force-di/test/classes/di_BindingTest.cls
@@ -39,7 +39,8 @@ private class di_BindingTest {
         Object boundInstance2 = binding.getInstance();
         // Then
         System.assert(boundInstance1 instanceof Bob);
-        System.assert(boundInstance1 === boundInstance2);
+        System.assert(boundInstance2 instanceof Bob);
+        System.assert(boundInstance1 !== boundInstance2);
     }
 
     @IsTest

--- a/force-di/test/classes/di_BindingTest.cls
+++ b/force-di/test/classes/di_BindingTest.cls
@@ -39,6 +39,7 @@ private class di_BindingTest {
         Object boundInstance2 = binding.getInstance();
         // Then
         System.assert(boundInstance1 instanceof Bob);
+        System.assert(boundInstance2 instanceof Bob);
         System.assert(boundInstance1 === boundInstance2);
     }
 
@@ -53,6 +54,7 @@ private class di_BindingTest {
         Object boundInstance2 = binding.getInstance(true);
         // Then
         System.assert(boundInstance1 instanceof Bob);
+        System.assert(boundInstance2 instanceof Bob);
         System.assert(boundInstance1 !== boundInstance2);
     }
 


### PR DESCRIPTION
Currently, when the di_Binding gets an instance of a class, it checks the value of the `Injected` instance variable, and if it is null, creates a new instance of the class and sets that variable to the new instance, and then returns the instance. This means that any subsequence call to the di_Binding instance to get a new instance of the bound object results in the "cached" result being returned. This means that the following line `di_Injector.Org.getInstance( MyClass.class )` always returns the same instance of the class, instead of constructing a new instance each time.

The "fix" is to remove the caching of the constructed class, and simply allow the di_Binding to get a new instance of the class on each call to getInstance().

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/apex-enterprise-patterns/force-di/71)
<!-- Reviewable:end -->
