### PR TITLE
Fix for test method givenApexBindingWhenGetNewInstanceThenNewInstance

### DIFF
--- a/force-di/test/classes/di_BindingTest.cls
+++ b/force-di/test/classes/di_BindingTest.cls
@@ -50,8 +50,8 @@ private class di_BindingTest {
             di_Binding.BindingType.Apex,
             Bob.class.getName(), null, null, Bob.class.getName(), null);
         // When
-        Object boundInstance1 = binding.getInstance(true);
-        Object boundInstance2 = binding.getInstance(true);
+        Object boundInstance1 = binding.getInstance(null, true);
+        Object boundInstance2 = binding.getInstance(null, true);
         // Then
         System.assert(boundInstance1 instanceof Bob);
         System.assert(boundInstance2 instanceof Bob);

--- a/force-di/test/testSuites/force_di_teststuite.testSuite-meta.xml
+++ b/force-di/test/testSuites/force_di_teststuite.testSuite-meta.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexTestSuite xmlns="http://soap.sforce.com/2006/04/metadata">
+    <testClassName>di_BindingConfigWrapperTest</testClassName>
     <testClassName>di_BindingParamTest</testClassName>
     <testClassName>di_BindingTest</testClassName>
     <testClassName>di_FlowTest</testClassName>


### PR DESCRIPTION
This is a small fix for PR #71 where an override for instance caching was implemented. 

The error was that the `getInstance(Object params)` was being invoked in the failing test method instead of the `getInstance(Object params, Boolean newInstance)`. This caused the `params` to not be null, and so the code expected that the created instance was an implementation of a `Provider`, which it wasn't.

See below the error message and the stack trace of the failing test:

```
di_Binding.BindingException: Apex binding di_BindingTest.Bob implementation di_BindingTest.Bob does not implement the Provider interface.

Class.di_Binding.ApexBinding.newInstance: line 413, column 1
Class.di_Binding.getInstance: line 82, column 1
Class.di_Binding.getInstance: line 70, column 1
Class.di_BindingTest.givenApexBindingWhenGetNewInstanceThenNewInstance: line 53, column 1
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/apex-enterprise-patterns/force-di/72)
<!-- Reviewable:end -->
