### PR TITLE
Minor improvement for tests

### DIFF
--- a/force-di/main/classes/di_Injector.cls
+++ b/force-di/main/classes/di_Injector.cls
@@ -144,22 +144,24 @@ public class di_Injector {
         @testVisible
         private List<di_BindingConfigWrapper> getDIBinding(){
             List<di_BindingConfigWrapper> recordList = new List<di_BindingConfigWrapper>();
-            List<di_Binding__mdt> bindingMDTRec = [SELECT QualifiedAPIName
-                                                        , DeveloperName
-                                                        , NamespacePrefix
-                                                        , Type__c
-                                                        , To__c
-                                                        , BindingObject__c
-                                                        , BindingObject__r.QualifiedApiName
-                                                        , BindingObjectAlternate__c
-                                                        , BindingSequence__c
-                                                     FROM di_Binding__mdt];
-            for(di_Binding__mdt records :bindingMDTRec) {
-                recordList.add(new di_BindingConfigWrapper(records));
-            }
+
             // When we want to mock data from metadata for injecting dependencies.
             if(di_Injector.mock_BindingConfigurationWrappersOuter != null) {
                 recordList = di_Injector.mock_BindingConfigurationWrappersOuter;
+            } else {
+                List<di_Binding__mdt> bindingMDTRec = [SELECT QualifiedAPIName
+                                                            , DeveloperName
+                                                            , NamespacePrefix
+                                                            , Type__c
+                                                            , To__c
+                                                            , BindingObject__c
+                                                            , BindingObject__r.QualifiedApiName
+                                                            , BindingObjectAlternate__c
+                                                            , BindingSequence__c
+                                                         FROM di_Binding__mdt];
+                for(di_Binding__mdt records :bindingMDTRec) {
+                    recordList.add(new di_BindingConfigWrapper(records));
+                }
             }
             return recordList;
         }

--- a/force-di/test/classes/di_InjectorTest.cls
+++ b/force-di/test/classes/di_InjectorTest.cls
@@ -146,7 +146,7 @@ private class di_InjectorTest {
     static void whenDeveloperNameIsEmptyThenGetInstanceShouldThrowException(){
 
         //given
-        di_Module module=new di_Module();
+        di_Module module = new di_Module();
         di_Injector injector = new di_Injector(module);
 
         //when
@@ -156,22 +156,8 @@ private class di_InjectorTest {
         } catch (di_Injector.InjectorException excp) {
             //then
             System.assertEquals('Request for Binding cannot take "developerName" parameter of null', excp.getMessage(), 'Expecting specific exception message');
-        }
-    }
-
-    @isTest
-    static void givenEmptyDeveloperNameGetInstanceShouldThrowException(){
-
-        //given
-        di_Module module=new di_Module();
-        di_Injector injector = new di_Injector(module);
-
-        //when
-        try {
-            injector.getInstance('', Account.getSObjectType(), null);
-            System.assert(false, 'Expecting that exception was thrown');
-        } catch (di_Injector.InjectorException excp) {
-            System.assertEquals('Request for Binding cannot take "developerName" parameter of null', excp.getMessage(), 'Expecting specific exception message');
+        } catch (Exception e) {
+            System.assert(false, 'Was expecting a di_Injector.InjectorException but instead received ' + e);
         }
     }
 
@@ -183,10 +169,10 @@ private class di_InjectorTest {
         di_Injector.mock_BindingConfigurationWrappersOuter = new List<di_BindingConfigWrapper> { 
             new di_BindingConfigWrapper(
                 'testQualifiedApiName',
-                'di_InjectorTest.InterfaceForTest', 
+                di_InjectorTest.InterfaceForTest.class.getName(), 
                 'testNamespacePrefix', 
                 'Apex',
-                'di_InjectorTest.ClassForTest',
+                di_InjectorTest.ClassForTest.class.getName(),
                 'Account',
                 'Account',
                 null,
@@ -195,7 +181,7 @@ private class di_InjectorTest {
         };
         //when
         di_InjectorTest.InterfaceForTest returnedInstance = 
-            (di_InjectorTest.InterfaceForTest)injector.getInstance('di_InjectorTest.InterfaceForTest', Account.SObjectType, null);
+            (di_InjectorTest.InterfaceForTest)injector.getInstance( di_InjectorTest.InterfaceForTest.class.getName(), Account.SObjectType, null);
 
         //then
         System.assert(returnedInstance instanceof di_InjectorTest.ClassForTest, 'Expecting that instance of class was returned');
@@ -209,10 +195,10 @@ private class di_InjectorTest {
         di_Injector.mock_BindingConfigurationWrappersOuter = new List<di_BindingConfigWrapper> { 
             new di_BindingConfigWrapper(
                 'testQualifiedApiName',
-                'di_InjectorTest.InterfaceForTest', 
+                di_InjectorTest.InterfaceForTest.class.getName(), 
                 'testNamespacePrefix', 
                 'Apex',
-                'di_InjectorTest.ClassForTest',
+                di_InjectorTest.ClassForTest.class.getName(),
                 null,
                 null,
                 'Account',
@@ -222,7 +208,7 @@ private class di_InjectorTest {
 
         //when
         di_InjectorTest.InterfaceForTest returnedInstance = 
-            (di_InjectorTest.InterfaceForTest)injector.getInstance('di_InjectorTest.InterfaceForTest', Account.SObjectType, null);
+            (di_InjectorTest.InterfaceForTest)injector.getInstance( di_InjectorTest.InterfaceForTest.class.getName(), Account.SObjectType, null);
 
         //then
         System.assert(returnedInstance instanceof di_InjectorTest.ClassForTest, 'Expecting that instance of class was returned');

--- a/force-di/test/classes/di_InjectorTest.cls
+++ b/force-di/test/classes/di_InjectorTest.cls
@@ -142,4 +142,118 @@ private class di_InjectorTest {
         system.assertEquals(true, hasException);
     }
 
+    @isTest
+    static void whenDeveloperNameIsEmptyThenGetInstanceShouldThrowException(){
+
+        //given
+        di_Module module=new di_Module();
+        di_Injector injector = new di_Injector(module);
+
+        //when
+        try {
+            injector.getInstance('', Account.getSObjectType(), null);
+            System.assert(false, 'Expecting that exception was thrown');
+        } catch (di_Injector.InjectorException excp) {
+            //then
+            System.assertEquals('Request for Binding cannot take "developerName" parameter of null', excp.getMessage(), 'Expecting specific exception message');
+        }
+    }
+
+    @isTest
+    static void givenEmptyDeveloperNameGetInstanceShouldThrowException(){
+
+        //given
+        di_Module module=new di_Module();
+        di_Injector injector = new di_Injector(module);
+
+        //when
+        try {
+            injector.getInstance('', Account.getSObjectType(), null);
+            System.assert(false, 'Expecting that exception was thrown');
+        } catch (di_Injector.InjectorException excp) {
+            System.assertEquals('Request for Binding cannot take "developerName" parameter of null', excp.getMessage(), 'Expecting specific exception message');
+        }
+    }
+
+    @isTest
+    static void givenInjectorWithBindingsThenBindingIsReturned(){
+
+        //given
+        di_Injector injector = di_Injector.Org;
+        di_Injector.mock_BindingConfigurationWrappersOuter = new List<di_BindingConfigWrapper> { 
+            new di_BindingConfigWrapper(
+                'testQualifiedApiName',
+                'di_InjectorTest.InterfaceForTest', 
+                'testNamespacePrefix', 
+                'Apex',
+                'di_InjectorTest.ClassForTest',
+                'Account',
+                'Account',
+                null,
+                1
+            )
+        };
+        //when
+        di_InjectorTest.InterfaceForTest returnedInstance = 
+            (di_InjectorTest.InterfaceForTest)injector.getInstance('di_InjectorTest.InterfaceForTest', Account.SObjectType, null);
+
+        //then
+        System.assert(returnedInstance instanceof di_InjectorTest.ClassForTest, 'Expecting that instance of class was returned');
+    }
+
+    @isTest
+    static void givenBindingsWithAlternateObjectNameThenBindingIsReturned(){
+
+        //given
+        di_Injector injector = di_Injector.Org;
+        di_Injector.mock_BindingConfigurationWrappersOuter = new List<di_BindingConfigWrapper> { 
+            new di_BindingConfigWrapper(
+                'testQualifiedApiName',
+                'di_InjectorTest.InterfaceForTest', 
+                'testNamespacePrefix', 
+                'Apex',
+                'di_InjectorTest.ClassForTest',
+                null,
+                null,
+                'Account',
+                1
+            )
+        };
+
+        //when
+        di_InjectorTest.InterfaceForTest returnedInstance = 
+            (di_InjectorTest.InterfaceForTest)injector.getInstance('di_InjectorTest.InterfaceForTest', Account.SObjectType, null);
+
+        //then
+        System.assert(returnedInstance instanceof di_InjectorTest.ClassForTest, 'Expecting that instance of class was returned');
+    }
+
+    @isTest
+    static void givenNoBindingsGetInstanceShouldThrowException(){
+
+        //given
+        String dummyBindingName = 'UnknownBinding';
+        di_Module module=new di_Module();
+        di_Injector injector = new di_Injector(module);
+
+        //when
+        try {
+            injector.getInstance(dummyBindingName, null);
+            System.assert(false, 'Expecting that exception was thrown');
+        } catch (di_Injector.InjectorException excp) {
+            //then
+            System.assertEquals('Binding for "' + dummyBindingName + '" not found', excp.getMessage(), 'Expecting specific exception message');
+        }
+
+    }
+
+    public interface InterfaceForTest {
+        void implementMe();
+    }
+
+    public class ClassForTest implements InterfaceForTest {
+        public ClassForTest() { }
+        public void implementMe(){}
+    }
+
 }


### PR DESCRIPTION
1. CustomMetadataModule: in getDIBinding there is no need to query for di_Binding__mdt if mock_BindingConfigurationWrappersOuter is provided, that's why I put it in the else clause.
2. Increased unit test code coverage for di_Injector class

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/apex-enterprise-patterns/force-di/80)
<!-- Reviewable:end -->
