### PR TITLE
add 'BindingName__c' to SOQL query

### DIFF
--- a/force-di/main/classes/di_Injector.cls
+++ b/force-di/main/classes/di_Injector.cls
@@ -151,6 +151,7 @@ public class di_Injector {
             } else {
                 List<di_Binding__mdt> bindingMDTRec = [SELECT QualifiedAPIName
                                                             , DeveloperName
+                                                            , BindingName__c
                                                             , NamespacePrefix
                                                             , Type__c
                                                             , To__c


### PR DESCRIPTION
Add `BindingName__c` to SQOL query to fix the below error when running tests.

```
System.SObjectException: SObject row was retrieved via SOQL without querying the requested field: di_Binding__mdt.BindingName__c
Class.di_BindingConfigWrapper.<init>: line 25, column 1
Class.di_Injector.CustomMetadataModule.getDIBinding: line 163, column 1
Class.di_Injector.CustomMetadataModule.configure: line 170, column 1
Class.di_Binding.Resolver.loadBindings: line 290, column 1
Class.di_Binding.Resolver.get: line 317, column 1
Class.di_Injector.getInstance: line 126, column 1
Class.di_Injector.getInstance: line 108, column 1
Class.di_Injector.getInstance: line 100, column 1
Class.Application.SelectorFactory.newInstance: line 61, column 1
Class.AccountSelector.newInstance: line 23, column 1
Class.AccountSelectorTest.shouldReturnEmptyListWhenSelectByIdDoesNotExist: line 83, column 1
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/apex-enterprise-patterns/force-di/85)
<!-- Reviewable:end -->
